### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate clock_ticks;
 extern crate quack;
 extern crate window;
 
-use std::thread::sleep;
+use std::thread::sleep; // fix this please i'm a noob and want to learn
 use std::time::duration::Duration;
 use std::cmp;
 use std::marker::{ PhantomData };


### PR DESCRIPTION
sleep from std::thread does not work anymore

compiler says: 

`   Compiling pistoncore-event_loop v0.0.14 (https://github.com/PistonDevelopers/event_loop#60e41738)
/home/andrew/.cargo/git/checkouts/event_loop-eab122f9bd640692/master/src/lib.rs:13:5: 13:23 error: unresolved import `std::thread::sleep`. There is no `sleep` in `std::thread`
/home/andrew/.cargo/git/checkouts/event_loop-eab122f9bd640692/master/src/lib.rs:13 use std::thread::sleep;
                                                                                       ^~~~~~~~~~~~~~~~~~
`